### PR TITLE
make frame scale adjustable by 1 percent steps

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -270,7 +270,7 @@ function Gladdy:SetupOptions()
                                         order = 4,
                                         min = .1,
                                         max = 2,
-                                        step = .1,
+                                        step = 0.01,
                                     },
                                     padding = {
                                         type = "range",


### PR DESCRIPTION
the frame scale is unnecessarily restrictive to 10% steps. this simple change fixes that and makes it adjustable in 1% steps.