### PR TITLE
prevent errors from nil DR icons

### DIFF
--- a/Modules/Diminishings.lua
+++ b/Modules/Diminishings.lua
@@ -645,7 +645,12 @@ function Diminishings:GetDRIcons(category)
     local icons = {}
     for k,v in pairs(DRData:GetSpells()) do
         if v == category then
-            icons[select(3, GetSpellInfo(k))] = format("|T%s:20|t %s", select(3, GetSpellInfo(k)), select(1, GetSpellInfo(k)))
+            local icon = select(3, GetSpellInfo(k))
+            if icon then
+                icons[icon] = format("|T%s:20|t %s", tostring(icon or "nil"), tostring(select(1, GetSpellInfo(k)) or "nil"))
+            else
+                print("Gladdy Diminishings.lua: nil icon for key: "..tostring(k or "nil").."; value: "..tostring(v or "nil"))
+            end
         end
     end
     return icons

--- a/Modules/Diminishings.lua
+++ b/Modules/Diminishings.lua
@@ -650,6 +650,7 @@ function Diminishings:GetDRIcons(category)
                 icons[icon] = format("|T%s:20|t %s", tostring(icon or "nil"), tostring(select(1, GetSpellInfo(k)) or "nil"))
             else
                 print("Gladdy Diminishings.lua: nil icon for key: "..tostring(k or "nil").."; value: "..tostring(v or "nil"))
+                print("Gladdy: Do you have a conflicting and incorrect copy of DRData?")
             end
         end
     end


### PR DESCRIPTION
Gladdy didn't work at all for me, and it was due to this error-prone code.  I've fixed it in my fork here and this pull request should help fix it upstream.

I honestly don't understand how that code could have worked for anyone else in TBC Classic, since the entire addon couldn't initialize without this fix.

Thanks for the addon.