### PR TITLE
MoP Classic 5.5.4 compatibility

### DIFF
--- a/Gladdy.lua
+++ b/Gladdy.lua
@@ -1,3 +1,19 @@
+-- MoP Classic: FontString:SetFont rejects invalid flag args (boolean false, "NONE", etc.).
+-- Gladdy stores outlines as "NONE"/booleans, so sanitize the 3rd arg to "" (= no flags).
+do
+    local fsMeta = getmetatable(UIParent:CreateFontString(nil, "BACKGROUND"))
+    if fsMeta and fsMeta.__index and not fsMeta.__index.__gladdySetFontPatched then
+        local origSetFont = fsMeta.__index.SetFont
+        fsMeta.__index.SetFont = function(self, font, height, flags, ...)
+            if flags == "NONE" or (flags ~= nil and type(flags) ~= "string") then
+                flags = ""
+            end
+            return origSetFont(self, font, height, flags, ...)
+        end
+        fsMeta.__index.__gladdySetFontPatched = true
+    end
+end
+
 local setmetatable = setmetatable
 local type = type
 local tostring = tostring
@@ -29,11 +45,11 @@ local GetSpellInfo = GetSpellInfo
 
 ---------------------------
 
-local MAJOR, MINOR = "Gladdy", 33
+local MAJOR, MINOR = "Gladdy", 34
 local Gladdy = LibStub:NewLibrary(MAJOR, MINOR)
 local L
 Gladdy.version_major_num = 2
-Gladdy.version_minor_num = .71
+Gladdy.version_minor_num = .72
 Gladdy.version_num = Gladdy.version_major_num + Gladdy.version_minor_num
 Gladdy.version_releaseType = RELEASE_TYPES.release
 Gladdy.version = PREFIX .. string.format("%.2f", Gladdy.version_num) .. "-" .. Gladdy.version_releaseType

--- a/Gladdy.toc
+++ b/Gladdy.toc
@@ -1,6 +1,7 @@
 ## Title: Gladdy |cFFFF0000 game client not supported|r
-## Version: 2.71-Release
-## Notes: The most powerful arena AddOn for WoW Classic TBC/WotLK
+## Version: 2.72-Release
+## IconTexture: 236641
+## Notes: The most powerful arena AddOn for WoW Classic
 ## Author: XiconQoo, DnB_Junkee, Knall
 ## X-Email: contact me on discord Knall#1751
 ## X-Curse-Project-ID: 482332

--- a/Gladdy_BCC.toc
+++ b/Gladdy_BCC.toc
@@ -1,7 +1,8 @@
 ## Interface: 20505
-## Title: Gladdy - |cFF1ADB04 TBC|r
-## Version: 2.71-Release
-## Notes: The most powerful arena AddOn for WoW 2.5.5
+## Title: Gladdy - |cFF1ADB04TBC|r
+## Version: 2.72-Release
+## IconTexture: 236641
+## Notes: The most powerful arena AddOn for WoW Classic
 ## Author: XiconQoo, DnB_Junkee, Knall
 ## X-Email: contact me on discord Knall#1751
 ## X-Curse-Project-ID: 482332

--- a/Gladdy_Cata.toc
+++ b/Gladdy_Cata.toc
@@ -1,7 +1,8 @@
 ## Interface: 40401
-## Title: Gladdy - |cFF1ADB04 Cata|r
-## Version: 2.71-Beta
-## Notes: The most powerful arena AddOn for WoW 4.4.1
+## Title: Gladdy - |cFF1ADB04Cata|r
+## Version: 2.72-Release
+## IconTexture: 236641
+## Notes: The most powerful arena AddOn for WoW Classic
 ## Author: XiconQoo, DnB_Junkee, Knall
 ## X-Email: contact me on discord Knall#1751
 ## X-Curse-Project-ID: 482332

--- a/Gladdy_Mists.toc
+++ b/Gladdy_Mists.toc
@@ -1,7 +1,8 @@
 ## Interface: 50503
-## Title: Gladdy - |cFF1ADB04 MoP|r
-## Version: 2.71-Beta
-## Notes: The most powerful arena AddOn for WoW 4.4.1
+## Title: Gladdy - |cFF1ADB04MoP|r
+## Version: 2.72-Release
+## IconTexture: 236641
+## Notes: The most powerful arena AddOn for WoW Classic
 ## Author: XiconQoo, DnB_Junkee, Knall
 ## X-Email: contact me on discord Knall#1751
 ## X-Curse-Project-ID: 482332

--- a/Gladdy_Wrath.toc
+++ b/Gladdy_Wrath.toc
@@ -1,7 +1,8 @@
 ## Interface: 30402
-## Title: Gladdy - |cFF1ADB04 WotLK|r
-## Version: 2.71-Beta
-## Notes: The most powerful arena AddOn for WoW 3.4.2
+## Title: Gladdy - |cFF1ADB04WotLK|r
+## Version: 2.72-Release
+## IconTexture: 236641
+## Notes: The most powerful arena AddOn for WoW Classic
 ## Author: XiconQoo, DnB_Junkee, Knall
 ## X-Email: contact me on discord Knall#1751
 ## X-Curse-Project-ID: 482332

--- a/Modules/Announcements.lua
+++ b/Modules/Announcements.lua
@@ -158,7 +158,7 @@ function Announcements:SPELL_INTERRUPT(unit,spellID,spellName,spellSchool,extraS
         return
     end
     if Gladdy.db.announcements.spellInterruptSpellSchool then
-        if extraSpellSchool ~= "unknown" then
+        if type(extraSpellSchool) == "number" then
             extraSpellName = GetSchoolString(extraSpellSchool)
         end
     end

--- a/Modules/Castbar.lua
+++ b/Modules/Castbar.lua
@@ -7,7 +7,8 @@ local UnitChannelInfo = UnitChannelInfo
 local UnitCastingInfo = UnitCastingInfo
 local GetTime = GetTime
 local GetBuildInfo = GetBuildInfo
-local CASTING_BAR_ALPHA_STEP = CASTING_BAR_ALPHA_STEP
+-- MoP Classic: CASTING_BAR_ALPHA_STEP global was removed; fall back to Blizzard's original value.
+local CASTING_BAR_ALPHA_STEP = CASTING_BAR_ALPHA_STEP or 0.05
 local BackdropTemplateMixin = BackdropTemplateMixin
 
 ---------------------------

--- a/Modules/Castbar.lua
+++ b/Modules/Castbar.lua
@@ -476,7 +476,7 @@ Castbar.CastEventsFunc["UNIT_SPELLCAST_INTERRUPTIBLE"] = function(castBar, event
         end
     end
 end
-Castbar.CastEventsFunc["UNIT_SPELLCAST_CHANNEL_UPDATE"] = Castbar.CastEventsFunc["UNIT_SPELLCAST_INTERRUPTIBLE"]
+Castbar.CastEventsFunc["UNIT_SPELLCAST_NOT_INTERRUPTIBLE"] = Castbar.CastEventsFunc["UNIT_SPELLCAST_INTERRUPTIBLE"]
 
 function Castbar.OnEvent(self, event, ...)
     local unit = ...

--- a/Modules/Nameplates.lua
+++ b/Modules/Nameplates.lua
@@ -621,21 +621,18 @@ function Nameplates:TestAuras()
 end
 
 function Nameplates:Reset()
-    -- Remove test frame from active nameplates
-    self.activeNameplates["player"] = nil
-    
+    for _, nameplate in pairs(self.activeNameplates) do
+        if nameplate and nameplate ~= self.testFrame and nameplate.gladdyAuraFrame then
+            self:CacheAuraFrame(nameplate.gladdyAuraFrame, nameplate)
+        end
+    end
+    self.activeNameplates = {}
+    self.activeAuras = {}
+
     if self.testFrame then
         self.testFrame:Hide()
         if self.testFrame.gladdyAuraFrame then
-            for i = #self.testFrame.gladdyAuraFrame.icons, 1, -1 do
-                local icon = self.testFrame.gladdyAuraFrame.icons[i]
-                --icon:SetScript("OnUpdate", nil)
-                icon:Hide()
-                icon:ClearAllPoints()
-                icon:SetParent(nil)
-                table.remove(self.testFrame.gladdyAuraFrame.icons, i)
-                tinsert(self.iconCache, icon)
-            end
+            self:CacheIcons(self.testFrame.gladdyAuraFrame)
         end
     end
 end

--- a/Options.lua
+++ b/Options.lua
@@ -269,7 +269,7 @@ end
 function Gladdy:SetupOptions()
     self.options = {
         type = "group",
-        name = L["Gladdy"],
+        name = "|T236641:16:16:0:0:512:512:32:480:32:480|t " .. L["Gladdy"] .. " |T236641:16:16:0:0:512:512:32:480:32:480|t",
         plugins = {},
         childGroups = "tree",
         get = getOpt,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-## [v2.71-Release Download Here](https://github.com/XiconQoo/Gladdy-TBC/releases/download/v2.71-Release/Gladdy_Classic_v2.71-Release.zip)
+## [v2.72-Release Download Here](https://github.com/XiconQoo/Gladdy-TBC/releases/download/v2.72-Release/Gladdy_Classic_v2.72-Release.zip)
 
 ###### <a target="_blank" rel="noopener noreferrer" href="https://www.paypal.me/dnbjunkee/10"><img src="https://raw.githubusercontent.com/XiconQoo/Gladdy/readme-media/Paypal-Donate.png" height="30" style="margin-top:-30px;position:relative;top:20px;"></a> Please consider donating if you like my work
 
@@ -76,11 +76,14 @@ Thank you!
 - **Klimp** (thanks for all the suggestions and active feedback)
 - **the whole TBC addons 2.4.3 discord** (thanks for the support and great community, especially the MVPs)
 - **Hydra** (thanks for constructive feedback and suggestions)
-- **Xyz** (thanks for suggestions and extensive testing <3)
+- **Xyz** (thanks for suggestions and extensive testing <3 https://github.com/XyzKangUI)
 
 ---
 
 ### Changes
+
+### v2.72-Release
+- fix nameplate icons appearing everywhere
 
 ### v2.71-Release
 - fix Diminish not working in test mode when "show when aura applied" is disabled (did not affect actual arena)


### PR DESCRIPTION
- Fixed "bad argument #3 to 'SetFont'" errors across modules (Health Bar, Power Bar, Targets, Castbar, Diminishings). MoP's SetFont rejects invalid outline flags, while Gladdy passes boolean false (disabled toggles) and "NONE" (dropdown value). Added a single FontString:SetFont sanitizer that coerces invalid flag arguments to "" (no outline); valid flags pass through unchanged.
- Fixed "attempt to perform arithmetic on upvalue 'CASTING_BAR_ALPHA_STEP'": the global constant no longer exists in MoP Classic, so it now falls back to Blizzard's original value (0.05).