### PR TITLE
nil auraFrame bug fix

### DIFF
--- a/Modules/Nameplates.lua
+++ b/Modules/Nameplates.lua
@@ -195,8 +195,10 @@ function Nameplates:CacheIcon(icon, auraFrame, index)
 end
 
 function Nameplates:CacheIcons(auraFrame)
-    for i = #auraFrame.icons, 1, -1 do
-        self:CacheIcon(auraFrame.icons[i], auraFrame, i)
+    if auraFrame and auraFrame.icons then
+        for i = #auraFrame.icons, 1, -1 do
+            self:CacheIcon(auraFrame.icons[i], auraFrame, i)
+        end
     end
 end
 


### PR DESCRIPTION
Message: Interface/AddOns/Gladdy/Modules/Nameplates.lua:199: attempt to index local 'auraFrame' (a nil value)
Time: Wed Jul 29 11:37:48 2026
Count: 1
Stack:
[Interface/AddOns/Gladdy/Modules/Nameplates.lua]:199: in function 'CacheIcons'
[Interface/AddOns/Gladdy/Modules/Nameplates.lua]:409: in function 'LayoutIcons'
[Interface/AddOns/Gladdy/Modules/Nameplates.lua]:388: in function '?'
[Interface/AddOns/Gladdy/Gladdy.lua]:159: in function 'Call'
[Interface/AddOns/Gladdy/Gladdy.lua]:165: in function 'SendMessage'
[Interface/AddOns/Gladdy/EventListener.lua]:405: in function 'ScanAuras'
[Interface/AddOns/Gladdy/EventListener.lua]:356: in function '?'
[Interface/AddOns/Gladdy/EventListener.lua]:30: in function <Interface/AddOns/Gladdy/EventListener.lua:29>

Locals:
self=Frame <Gladdy.lua:170>{
 defaults=<table>
 messages=<table>
 activeAuras=<table>
 name="Nameplates"
 auraFrameCache=<table>
 priority=0
 activeNameplates=<table>
 iconCache=<table>
}
auraFrame=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)="attempt to index local 'auraFrame' (a nil value)"