### PR TITLE
Fix interrupt announcement crash on nil spell school

### DIFF
--- a/Modules/Announcements.lua
+++ b/Modules/Announcements.lua
@@ -158,7 +158,10 @@ function Announcements:SPELL_INTERRUPT(unit,spellID,spellName,spellSchool,extraS
         return
     end
     if Gladdy.db.announcements.spellInterruptSpellSchool then
-        if extraSpellSchool ~= "unknown" then
+        -- extraSpellSchool can be nil (e.g. interrupting a channel), and the
+        -- "unknown" check doesn't catch nil, so it reaches GetSchoolString and
+        -- errors. Only look up a real (numeric) school; otherwise keep the name.
+        if type(extraSpellSchool) == "number" then
             extraSpellName = GetSchoolString(extraSpellSchool)
         end
     end


### PR DESCRIPTION
SPELL_INTERRUPT can pass a nil extraSpellSchool (e.g. when interrupting a channeled spell), and the "unknown" guard doesn't catch nil, so it reaches GetSchoolString(nil) and errors:

  Announcements.lua: bad argument #1 to 'GetSchoolString'
  (Usage: C_Spell.GetSchoolString(schoolMask))

Guard with type(extraSpellSchool) == "number"; the spell name is kept as the fallback when no school is available.